### PR TITLE
Allow to send an array of values

### DIFF
--- a/src/SAML2/Builder/AssertionBuilder.php
+++ b/src/SAML2/Builder/AssertionBuilder.php
@@ -197,7 +197,10 @@ class AssertionBuilder
     public function setAttribute($name, $value)
     {
         $attributes = $this->assertion->getAttributes();
-        $attributes[$name] = [$value];
+        if (!is_array($value)) {
+            $value = [$value];
+        }
+        $attributes[$name] = $value;
 
         return $this->setAttributes($attributes);
     }


### PR DESCRIPTION
Why I need it for example:
To be able to send:
```
                    'groups' => function (UserInterface $user) {
                        /** @var User $user */
                        $groups = [];
                        foreach ($user->getTeams() as $team) {
                            $groups[] = $team->getName();
                        }
                        return  $groups;
                    },
```