### PR TITLE
Allow to send an array of values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fix
   - SubjectConfirmationData notBefore must be null for Bearer confirmation
+  - `AssertionBuilder.setNotBefore` should set `NotBefore` subjectConfirmationData and not `NotOnOrAfter`
 
 ## v0.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## v0.10.0
+### Add
+  - Able to set `assertionNotBeforeInterval` as `null` (fix for `SubjectConfirmationData notBefore`)
+  - Allow to send an array of values for `attributes`
+  - Add validAudiences in the SP configuration
+
+### Fix
+  - SubjectConfirmationData notBefore must be null for Bearer confirmation
+
 ## v0.9.1
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ class SamlServiceProviderRepository implements ServiceProviderRepository
                         return $user->getLastName();
                     },
                 ],
+                "validAudiences" => [
+                    "https://test.fake/saml/acs",
+                ],
                 "assertionNotBeforeInterval" => new \DateInterval('PT0S'),
                 "assertionNotOnOrAfterInterval" => new \DateInterval('PT5M'),
                 "assertionSessionNotOnOrAfterInterval" => new \DateInterval('P1D'),

--- a/src/Entity/ServiceProvider.php
+++ b/src/Entity/ServiceProvider.php
@@ -153,4 +153,12 @@ class ServiceProvider extends \SAML2_Configuration_ServiceProvider
     {
         return $this->get('maxRetryLogin', 0);
     }
+
+    /**
+     * @return array|null
+     */
+    public function getValidAudiences()
+    {
+        return $this->get('validAudiences');
+    }
 }

--- a/src/SAML2/Builder/AssertionBuilder.php
+++ b/src/SAML2/Builder/AssertionBuilder.php
@@ -50,7 +50,6 @@ class AssertionBuilder
         $confirmation->Method = \SAML2_Const::CM_BEARER;
 
         $confirmationData = new \SAML2_XML_saml_SubjectConfirmationData();
-        $confirmationData->NotBefore = $this->issueInstant->getTimestamp();
 
         $confirmation->SubjectConfirmationData = $confirmationData;
 
@@ -86,9 +85,11 @@ class AssertionBuilder
 
         $this->assertion->setNotBefore($beforeTime->getTimestamp());
 
-        $confirmation = $this->assertion->getSubjectConfirmation()[0];
-        $confirmation->SubjectConfirmationData->NotOnOrAfter = $beforeTime->getTimestamp();
-        $this->assertion->setSubjectConfirmation([$confirmation]);
+        if ($interval !== null) {
+            $confirmation = $this->assertion->getSubjectConfirmation()[0];
+            $confirmation->SubjectConfirmationData->NotOnOrAfter = $beforeTime->getTimestamp();
+            $this->assertion->setSubjectConfirmation([$confirmation]);
+        }
 
         return $this;
     }

--- a/src/SAML2/Builder/AssertionBuilder.php
+++ b/src/SAML2/Builder/AssertionBuilder.php
@@ -197,7 +197,10 @@ class AssertionBuilder
     public function setAttribute($name, $value)
     {
         $attributes = $this->assertion->getAttributes();
-        $attributes[$name] = [$value];
+        if (!is_array($value)) {
+            $value = [$value];
+        }
+        $attributes[$name] = $value;
 
         return $this->setAttributes($attributes);
     }

--- a/src/SAML2/Builder/AssertionBuilder.php
+++ b/src/SAML2/Builder/AssertionBuilder.php
@@ -266,6 +266,13 @@ class AssertionBuilder
         return $this;
     }
 
+    public function setValidAudiences(array $validAudiences = NULL)
+    {
+        $this->assertion->setValidAudiences($validAudiences);
+
+        return $this;
+    }
+
     /**
      * @param \XMLSecurityKey $privateKey
      * @param \XMLSecurityKey $publicCert

--- a/src/SAML2/Builder/AssertionBuilder.php
+++ b/src/SAML2/Builder/AssertionBuilder.php
@@ -86,8 +86,9 @@ class AssertionBuilder
         $this->assertion->setNotBefore($beforeTime->getTimestamp());
 
         if ($interval !== null) {
+            /** @var \SAML2_XML_saml_SubjectConfirmation $confirmation */
             $confirmation = $this->assertion->getSubjectConfirmation()[0];
-            $confirmation->SubjectConfirmationData->NotOnOrAfter = $beforeTime->getTimestamp();
+            $confirmation->SubjectConfirmationData->NotBefore = $beforeTime->getTimestamp();
             $this->assertion->setSubjectConfirmation([$confirmation]);
         }
 

--- a/src/SAML2/Provider/HostedIdentityProviderProcessor.php
+++ b/src/SAML2/Provider/HostedIdentityProviderProcessor.php
@@ -589,8 +589,10 @@ class HostedIdentityProviderProcessor implements EventSubscriberInterface
 
 
         $assertionBuilder = new AssertionBuilder();
+        if ($serviceProvider->getAssertionNotBeforeInterval()) {
+            $assertionBuilder->setNotBefore($serviceProvider->getAssertionNotBeforeInterval());
+        }
         $assertionBuilder
-            ->setNotBefore($serviceProvider->getAssertionNotBeforeInterval())
             ->setNotOnOrAfter($serviceProvider->getAssertionNotOnOrAfterInterval())
             ->setSessionNotOnOrAfter($serviceProvider->getAssertionSessionNotOnORAfterInterval())
             ->setIssuer($this->identityProvider->getEntityId())
@@ -598,7 +600,8 @@ class HostedIdentityProviderProcessor implements EventSubscriberInterface
             ->setConfirmationMethod(SAML2_Const::CM_BEARER)
             ->setInResponseTo($authnRequest->getId())
             ->setRecipient($serviceProvider->getAssertionConsumerUrl())
-            ->setAuthnContext($state->getAuthnContext());
+            ->setAuthnContext($state->getAuthnContext())
+            ->setValidAudiences($serviceProvider->getValidAudiences());
         foreach ($serviceProvider->getAttributes() as $attributeName => $attributeCallback) {
             $assertionBuilder->setAttribute($attributeName, $attributeCallback($user));
         }

--- a/src/SAML2/Provider/HostedIdentityProviderProcessor.php
+++ b/src/SAML2/Provider/HostedIdentityProviderProcessor.php
@@ -589,10 +589,8 @@ class HostedIdentityProviderProcessor implements EventSubscriberInterface
 
 
         $assertionBuilder = new AssertionBuilder();
-        if ($serviceProvider->getAssertionNotBeforeInterval()) {
-            $assertionBuilder->setNotBefore($serviceProvider->getAssertionNotBeforeInterval());
-        }
         $assertionBuilder
+            ->setNotBefore($serviceProvider->getAssertionNotBeforeInterval())
             ->setNotOnOrAfter($serviceProvider->getAssertionNotOnOrAfterInterval())
             ->setSessionNotOnOrAfter($serviceProvider->getAssertionSessionNotOnORAfterInterval())
             ->setIssuer($this->identityProvider->getEntityId())


### PR DESCRIPTION
Why I need it for example:
To be able to send:
```
                    'groups' => function (UserInterface $user) {
                        /** @var User $user */
                        $groups = [];
                        foreach ($user->getTeams() as $team) {
                            $groups[] = $team->getName();
                        }
                        return  $groups;
                    },
```